### PR TITLE
Creating PgCat Helm Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
-# pgcat-helm-chart
+# PgCat Helm Chart
+
+The PgCat Helm Chart is a Helm chart implementation for PgCat.
+
+It is a PostgreSQL pooler and proxy (like PgBouncer) with support for sharding, load balancing, failover and mirroring.
+
+## Installation
+
+You can install the helm chart with:
+
+```bash
+helm install -f values.yaml pgcat
+```
+
+or through the chart's requirements:
+
+```yaml
+... todo
+```
+
+## Configuration
+
+To configure PgCat, create a `values.yaml` file and add the following settings (as an example):
+
+```yaml
+... todo
+```
+
+For a full overview of all the configurations allowed, please refer to the [values.yaml](./chart/values.yaml) file.
+
+For further information about the configuration of pgcat, refer to the official documentation under <https://www.pgcat.org/config.html>
+
+### PgCat Exporter configuration
+
+Additionally to the deployment of `pgcat`, a `prometheus-exporter` for metrics can be also deployed as a sidecar container, by appending the following as an example of configuration:
+
+```yaml
+... todo
+```
+
+> note: the above snippet assumes you have configured previously a secret named `secret` in your cluster, containing two keys, `pgcat-user` and `pgcat-password`. For information about how to configure a secret in your cluster, refer to the official documentation under <https://kubernetes.io/docs/concepts/configuration/secret/#use-cases>
+
+## Development
+
+In order to prepare a new release with new changes, maintainers are encouraged to follow the next conventions:
+
+- To create a new branch called `release-0.X.Y`.
+- To modify `chart\Chart.yaml` `appVersion` and `version` accordingly. Pushing this will generate a helm package in the form `pgcat-release-0.X.Y`. Time to test.
+- Once we are ready to go production, merge into master.
+- Finally, create a new `tag` in GitHub (for example, `0.0.2`). This will generate the final `pgcat-0.0.2` helm package.

--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,16 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+appVersion: "1.1.1"
+description: PgCat chart
+home: https://github.com/pulzeai/pgcat
+name: pgcat
+version: 0.0.1

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,0 +1,1 @@
+# pgcat-helm-chart

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,50 @@
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "pgcat.fullname" -}}
+{{- $name := .Values.nameOverride }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "pgcat.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "pgcat.labels" -}}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "pgcat.chart" . }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels }}
+{{- end }}
+{{ include "pgcat.selectorLabels" . }}
+{{- end }}
+
+
+{{/*
+Selector labels
+*/}}
+{{- define "pgcat.selectorLabels" -}}
+app: {{ include "pgcat.fullname" . }}
+release: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Get the pgcat config file name.
+*/}}
+{{- define "pgcat.configFile" -}}
+{{- printf "%s-config-file" (include "pgcat.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Get the pgcat serverpassword secret name.
+*/}}
+{{- define "pgcat.serverpasswordName" -}}
+{{- printf "%s-userlist" (include "pgcat.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/chart/templates/_pgcat.toml.tpl
+++ b/chart/templates/_pgcat.toml.tpl
@@ -1,0 +1,41 @@
+{{/*
+
+PgCat.toml is a configuration file used to specify PgCat parameters and identify user-specific parameters.
+It can contain include directives to split the file into separate parts.
+
+For further information, refer to https://postgresml.org/docs/product/pgcat/configuration
+
+*/}}
+
+{{ define "pgcat.toml" }}
+
+{{/* [databases] section */}}
+{{- if $.Values.databases }}
+  {{ printf "[databases]" }}
+  {{- range $key, $value := .Values.databases }}
+    {{ $key }} ={{ range $k, $v := $value }} {{ $k }}={{ $v }}{{ end }}
+  {{- end }}
+{{- end }}
+
+{{/* [pgcat] section */}}
+{{- if $.Values.pgcat }}
+  {{ printf "[pgcat]" }}
+  {{- range $k, $v := $.Values.pgcat }}
+    {{ $k }} = {{ $v }}
+  {{- end }}
+{{- end }}
+
+{{/* [users] section */}}
+{{- if $.Values.users }}
+  {{ printf "[users]" }}
+  {{- range $k, $v := $.Values.users }}
+    {{ $k }} = {{ $v }}
+  {{- end }}
+{{- end }}
+
+{{/* include is a special configuration within [pgcat] section */}}
+{{- if $.Values.include }}
+  {{ printf "%s %s" "%include" $.Values.include }}
+{{- end }}
+
+{{ end }}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "pgcat.configFile" . }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "pgcat.labels" . | nindent 4 }}
+data:
+  pgcat.toml: |-
+{{ include "pgcat.toml" . | indent 4 }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,154 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "pgcat.fullname" . }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "pgcat.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  {{- if .Values.deployment.strategy }}
+  strategy: {{ .Values.deployment.strategy | toYaml | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "pgcat.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "pgcat.labels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
+    spec:
+      affinity:
+        {{- if eq .Values.antiAffinity "hard" }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: {{ .Values.affinity.podAntiAffinity.topologyKey }}
+              labelSelector:
+                matchLabels:
+                  {{- include "pgcat.selectorLabels" . | nindent 18 }}
+        {{- else if eq .Values.antiAffinity "soft" }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: {{ .Values.affinity.podAntiAffinity.topologyKey }}
+                labelSelector:
+                  matchLabels:
+                    {{- include "pgcat.selectorLabels" . | nindent 20 }}
+        {{- end }}
+        {{- if .Values.nodeAffinity }}
+        nodeAffinity:
+          {{- toYaml .Values.nodeAffinity | nindent 10 }}
+        {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          projected:
+            sources:
+              - configMap:          
+                  name: {{ include "pgcat.configFile" . }}
+      {{- if .Values.serverpasswordName }}
+              - secret:
+                  name: {{ include "pgcat.serverpasswordName" . }}
+      {{- end }}
+      {{- if .Values.extraVolumes -}}
+      {{ toYaml .Values.extraVolumes | nindent 8 }}
+      {{ end -}}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{ if .Values.extraInitContainers -}}
+      initContainers:
+      {{ toYaml .Values.extraInitContainers | nindent 8 }}
+      {{ end -}}
+      containers:
+        - name: pgcat
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: pgcat
+              containerPort: {{ .Values.internalPort }}
+          {{- if .Values.deployment.readinessProbe.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.internalPort }}
+            initialDelaySeconds: {{ .Values.deployment.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.deployment.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.deployment.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.deployment.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.deployment.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.deployment.livenessProbe.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.internalPort }}
+            initialDelaySeconds: {{ .Values.deployment.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.deployment.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.deployment.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.deployment.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.deployment.livenessProbe.failureThreshold }}
+          {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                # So termination grace period is handling by terminationGracePeriodSeconds
+                command: ["/bin/sh", "-c", "killall -INT pgcat && sleep infinity"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ['all']
+          volumeMounts:
+            - name: config
+              mountPath: /etc/pgcat
+              readOnly: true
+            {{- if .Values.extraVolumeMounts -}}
+            {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+          {{- if .Values.resources }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+        {{- if .Values.pgcatExporter.enabled }}
+        - name: exporter
+          image: "{{ .Values.pgcatExporter.image.repository }}:{{ .Values.pgcatExporter.image.tag }}"
+          imagePullPolicy: {{ .Values.pgcatExporter.image.pullPolicy }}
+          args:
+          - --web.listen-address=:{{ .Values.pgcatExporter.port }}
+          - --web.telemetry-path=/metrics
+          - --log.level={{ .Values.pgcatExporter.log.level }}
+          - --log.format={{ .Values.pgcatExporter.log.format }}
+          - --pgcat.connectionString=postgres://$(pgcat_USER):$(pgcat_PWD)@localhost:$(pgcat_PORT)/pgcat?sslmode=disable&connect_timeout=10
+          env:
+            {{- if .Values.pgcatExporter.extraEnvFrom }}
+            {{- toYaml .Values.pgcatExporter.extraEnvFrom | nindent 12 }}
+            {{- end }}
+            {{- if .Values.pgcatExporter.extraEnv }}
+            {{- toYaml .Values.pgcatExporter.extraEnv | nindent 12 }}
+            {{- end }}
+          {{- if .Values.pgcatExporter.resources }}
+          resources:
+          {{- toYaml .Values.pgcatExporter.resources | nindent 12 }}
+          {{- end }}
+          ports:
+          - name: http-metrics-pg
+            containerPort: {{ .Values.pgcatExporter.port }}
+            protocol: TCP
+        {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}
+

--- a/chart/templates/pdb.yaml
+++ b/chart/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.maxUnavailable -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "pgcat.fullname" . }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "pgcat.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "pgcat.selectorLabels" . | nindent 6 }}
+  maxUnavailable: {{ .Values.maxUnavailable }}
+{{- end -}}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.service.enabled  }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ default (include "pgcat.fullname" .) .Values.service.name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "pgcat.labels" . | nindent 4 }}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "pgcat.selectorLabels" . | nindent 6 }}
+  ports:
+    - port: {{ .Values.servicePort }}
+      targetPort: {{ .Values.internalPort }}
+      protocol: TCP
+      name: pgcat
+    {{- if .Values.pgcatExporter.enabled }}
+    - port: {{ .Values.pgcatExporter.port }}
+      targetPort: http-metrics-pg
+      protocol: TCP
+      name: http-metrics-pg
+    {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,499 @@
+
+nameOverride: "pgcat"
+
+replicaCount: 1
+internalPort: 6432
+servicePort: 6432
+antiAffinity: soft
+nodeAffinity: {} # optionally define nodeAffinity
+tolerations: [] # optionally define tolerations
+
+## Node labels for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+nodeSelector: {} # optionally define nodeSelector
+
+# PodDisruptionBudget spec.maxUnavailable
+maxUnavailable: 1
+
+image:
+  repository: ghcr.io/postgresml/pgcat
+  tag: 1.1.1
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+deployment:
+  terminationGracePeriodSeconds: 120
+  readinessProbe:
+    enabled: true
+    # defaults to the internalPort port
+    port:
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
+  livenessProbe:
+    enabled: true
+    # defaults to the internalPort port
+    port:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
+
+  # strategy is utilized to configure the desired upgrade approach and
+  # configuration for the deployment.  See the Kubernetes documentation
+  # related to this subject.
+  # https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  strategy: {}
+
+
+# Service configuration
+service:
+  enabled: true
+  type: ClusterIP
+  name: ""
+  annotations: {}
+
+## Labels to add to the pod metadata
+##
+podLabels: {}
+# key: value
+
+## Annotations to add to the pod metadata
+podAnnotations: {}
+  # prometheus.io/scrape: "true"
+  # prometheus.io/port: "9127"
+  # prometheus.io/path: "/metrics"
+
+affinity:
+  podAntiAffinity:
+    topologyKey: kubernetes.io/hostname
+
+###
+### PgCat configuration
+### - https://postgresml.org/docs/product/pgcat/configuration
+###
+databases: {}
+  # <dbname>:
+  #   dbname: foo
+  #   host: "dbod-foo.cern.ch"
+  #   port: 5432
+  #   user: bar
+  #   password: xxx
+  #   auth_user: pgcat
+  #   pool_size: 20
+  #   min_pool_size: 0
+  #   reserve_pool: 0
+  #   connect_query:
+  #   pool_mode: transaction
+  #   max_db_connections: 20
+  #   client_encoding: UTF8
+  #   datestyle:
+  #   timezone: UTC
+
+## User specific configuration
+users: {}
+  # pool_mode:
+  # max_user_connections:
+
+## Configuration section
+pgcat:
+  #
+  # PgCat config example.
+  #
+
+  #
+  # General pooler settings
+  [general]
+  # What IP to run on, 0.0.0.0 means accessible from everywhere.
+  host = "0.0.0.0"
+
+  # Port to run on, same as PgBouncer used in this example.
+  port = 6432
+
+  # Whether to enable prometheus exporter or not.
+  enable_prometheus_exporter = true
+
+  # Port at which prometheus exporter listens on.
+  prometheus_exporter_port = 9930
+
+  # How long to wait before aborting a server connection (ms).
+  connect_timeout = 5000 # milliseconds
+
+  # How long an idle connection with a server is left open (ms).
+  idle_timeout = 30000 # milliseconds
+
+  # Max connection lifetime before it's closed, even if actively used.
+  server_lifetime = 86400000 # 24 hours
+
+  # How long a client is allowed to be idle while in a transaction (ms).
+  idle_client_in_transaction_timeout = 0 # milliseconds
+
+  # How much time to give the health check query to return with a result (ms).
+  healthcheck_timeout = 1000 # milliseconds
+
+  # How long to keep connection available for immediate re-use, without running a healthcheck query on it
+  healthcheck_delay = 30000 # milliseconds
+
+  # How much time to give clients during shutdown before forcibly killing client connections (ms).
+  shutdown_timeout = 60000 # milliseconds
+
+  # How long to ban a server if it fails a health check (seconds).
+  ban_time = 60 # seconds
+
+  # If we should log client connections
+  log_client_connections = false
+
+  # If we should log client disconnections
+  log_client_disconnections = false
+
+  # When set to true, PgCat reloads configs if it detects a change in the config file.
+  autoreload = 15000
+
+  # Number of worker threads the Runtime will use (4 by default).
+  worker_threads = 5
+
+  # Number of seconds of connection idleness to wait before sending a keepalive packet to the server.
+  tcp_keepalives_idle = 5
+  # Number of unacknowledged keepalive packets allowed before giving up and closing the connection.
+  tcp_keepalives_count = 5
+  # Number of seconds between keepalive packets.
+  tcp_keepalives_interval = 5
+
+  # Path to TLS Certificate file to use for TLS connections
+  # tls_certificate = ".circleci/server.cert"
+  # Path to TLS private key file to use for TLS connections
+  # tls_private_key = ".circleci/server.key"
+
+  # Enable/disable server TLS
+  server_tls = false
+
+  # Verify server certificate is completely authentic.
+  verify_server_certificate = false
+
+  # User name to access the virtual administrative database (pgbouncer or pgcat)
+  # Connecting to that database allows running commands like `SHOW POOLS`, `SHOW DATABASES`, etc..
+  admin_username = "admin_user"
+  # Password to access the virtual administrative database
+  admin_password = "admin_pass"
+
+  # Default plugins that are configured on all pools.
+  [plugins]
+
+  # Prewarmer plugin that runs queries on server startup, before giving the connection
+  # to the client.
+  [plugins.prewarmer]
+  enabled = false
+  queries = [
+    "SELECT pg_prewarm('pgbench_accounts')",
+  ]
+
+  # Log all queries to stdout.
+  [plugins.query_logger]
+  enabled = false
+
+  # Block access to tables that Postgres does not allow us to control.
+  [plugins.table_access]
+  enabled = false
+  tables = [
+    "pg_user",
+    "pg_roles",
+    "pg_database",
+  ]
+
+  # Intercept user queries and give a fake reply.
+  [plugins.intercept]
+  enabled = true
+
+  [plugins.intercept.queries.0]
+
+  query = "select current_database() as a, current_schemas(false) as b"
+  schema = [
+    ["a", "text"],
+    ["b", "text"],
+  ]
+  result = [
+    ["${DATABASE}", "{public}"],
+  ]
+
+  [plugins.intercept.queries.1]
+
+  query = "select current_database(), current_schema(), current_user"
+  schema = [
+    ["current_database", "text"],
+    ["current_schema", "text"],
+    ["current_user", "text"],
+  ]
+  result = [
+    ["${DATABASE}", "public", "${USER}"],
+  ]
+
+
+  # pool configs are structured as pool.<pool_name>
+  # the pool_name is what clients use as database name when connecting.
+  # For a pool named `sharded_db`, clients access that pool using connection string like
+  # `postgres://sharding_user:sharding_user@pgcat_host:pgcat_port/sharded_db`
+  [pools.sharded_db]
+  # Pool mode (see PgBouncer docs for more).
+  # `session` one server connection per connected client
+  # `transaction` one server connection per client transaction
+  pool_mode = "transaction"
+
+  # Load balancing mode
+  # `random` selects the server at random
+  # `loc` selects the server with the least outstanding busy conncetions
+  load_balancing_mode = "random"
+
+  # If the client doesn't specify, PgCat routes traffic to this role by default.
+  # `any` round-robin between primary and replicas,
+  # `replica` round-robin between replicas only without touching the primary,
+  # `primary` all queries go to the primary unless otherwise specified.
+  default_role = "any"
+
+  # Prepared statements cache size.
+  # TODO: update documentation
+  prepared_statements_cache_size = 500
+
+  # If Query Parser is enabled, we'll attempt to parse
+  # every incoming query to determine if it's a read or a write.
+  # If it's a read query, we'll direct it to a replica. Otherwise, if it's a write,
+  # we'll direct it to the primary.
+  query_parser_enabled = true
+
+  # If the query parser is enabled and this setting is enabled, we'll attempt to
+  # infer the role from the query itself.
+  query_parser_read_write_splitting = true
+
+  # If the query parser is enabled and this setting is enabled, the primary will be part of the pool of databases used for
+  # load balancing of read queries. Otherwise, the primary will only be used for write
+  # queries. The primary can always be explicitly selected with our custom protocol.
+  primary_reads_enabled = true
+
+  # Allow sharding commands to be passed as statement comments instead of
+  # separate commands. If these are unset this functionality is disabled.
+  # sharding_key_regex = '/\* sharding_key: (\d+) \*/'
+  # shard_id_regex = '/\* shard_id: (\d+) \*/'
+  # regex_search_limit = 1000 # only look at the first 1000 characters of SQL statements
+
+  # Defines the behavior when no shard is selected in a sharded system.
+  # `random`: picks a shard at random
+  # `random_healthy`: picks a shard at random favoring shards with the least number of recent errors
+  # `shard_<number>`: e.g. shard_0, shard_4, etc. picks a specific shard, everytime
+  # no_shard_specified_behavior = "shard_0"
+
+  # So what if you wanted to implement a different hashing function,
+  # or you've already built one and you want this pooler to use it?
+  # Current options:
+  # `pg_bigint_hash`: PARTITION BY HASH (Postgres hashing function)
+  # `sha1`: A hashing function based on SHA1
+  sharding_function = "pg_bigint_hash"
+
+  # Query to be sent to servers to obtain the hash used for md5 authentication. The connection will be
+  # established using the database configured in the pool. This parameter is inherited by every pool
+  # and can be redefined in pool configuration.
+  # auth_query="SELECT usename, passwd FROM pg_shadow WHERE usename='$1'"
+
+  # User to be used for connecting to servers to obtain the hash used for md5 authentication by sending the query
+  # specified in `auth_query_user`. The connection will be established using the database configured in the pool.
+  # This parameter is inherited by every pool and can be redefined in pool configuration.
+  # auth_query_user = "sharding_user"
+
+  # Password to be used for connecting to servers to obtain the hash used for md5 authentication by sending the query
+  # specified in `auth_query_user`. The connection will be established using the database configured in the pool.
+  # This parameter is inherited by every pool and can be redefined in pool configuration.
+  # auth_query_password = "sharding_user"
+
+  # Automatically parse this from queries and route queries to the right shard!
+  # automatic_sharding_key = "data.id"
+
+  # Idle timeout can be overwritten in the pool
+  idle_timeout = 40000
+
+  # Connect timeout can be overwritten in the pool
+  connect_timeout = 3000
+
+  # When enabled, ip resolutions for server connections specified using hostnames will be cached
+  # and checked for changes every `dns_max_ttl` seconds. If a change in the host resolution is found
+  # old ip connections are closed (gracefully) and new connections will start using new ip.
+  # dns_cache_enabled = false
+
+  # Specifies how often (in seconds) cached ip addresses for servers are rechecked (see `dns_cache_enabled`).
+  # dns_max_ttl = 30
+
+  # Plugins can be configured on a pool-per-pool basis. This overrides the global plugins setting,
+  # so all plugins have to be configured here again.
+  [pool.sharded_db.plugins]
+
+  [pools.sharded_db.plugins.prewarmer]
+  enabled = true
+  queries = [
+    "SELECT pg_prewarm('pgbench_accounts')",
+  ]
+
+  [pools.sharded_db.plugins.query_logger]
+  enabled = false
+
+  [pools.sharded_db.plugins.table_access]
+  enabled = false
+  tables = [
+    "pg_user",
+    "pg_roles",
+    "pg_database",
+  ]
+
+  [pools.sharded_db.plugins.intercept]
+  enabled = true
+
+  [pools.sharded_db.plugins.intercept.queries.0]
+
+  query = "select current_database() as a, current_schemas(false) as b"
+  schema = [
+    ["a", "text"],
+    ["b", "text"],
+  ]
+  result = [
+    ["${DATABASE}", "{public}"],
+  ]
+
+  [pools.sharded_db.plugins.intercept.queries.1]
+
+  query = "select current_database(), current_schema(), current_user"
+  schema = [
+    ["current_database", "text"],
+    ["current_schema", "text"],
+    ["current_user", "text"],
+  ]
+  result = [
+    ["${DATABASE}", "public", "${USER}"],
+  ]
+
+  # User configs are structured as pool.<pool_name>.users.<user_index>
+  # This section holds the credentials for users that may connect to this cluster
+  [pools.sharded_db.users.0]
+  # PostgreSQL username used to authenticate the user and connect to the server
+  # if `server_username` is not set.
+  username = "sharding_user"
+
+  # PostgreSQL password used to authenticate the user and connect to the server
+  # if `server_password` is not set.
+  password = "sharding_user"
+
+  pool_mode = "transaction"
+
+  # PostgreSQL username used to connect to the server.
+  # server_username = "another_user"
+
+  # PostgreSQL password used to connect to the server.
+  # server_password = "another_password"
+
+  # Maximum number of server connections that can be established for this user
+  # The maximum number of connection from a single Pgcat process to any database in the cluster
+  # is the sum of pool_size across all users.
+  pool_size = 9
+
+
+  # Maximum query duration. Dangerous, but protects against DBs that died in a non-obvious way.
+  # 0 means it is disabled.
+  statement_timeout = 0
+
+  [pools.sharded_db.users.1]
+  username = "other_user"
+  password = "other_user"
+  pool_size = 21
+  statement_timeout = 15000
+  connect_timeout = 1000
+  idle_timeout = 1000
+
+  # Shard configs are structured as pool.<pool_name>.shards.<shard_id>
+  # Each shard config contains a list of servers that make up the shard
+  # and the database name to use.
+  [pools.sharded_db.shards.0]
+  # Array of servers in the shard, each server entry is an array of `[host, port, role]`
+  servers = [["127.0.0.1", 5432, "primary"], ["localhost", 5432, "replica"]]
+
+  # Array of mirrors for the shard, each mirror entry is an array of `[host, port, index of server in servers array]`
+  # Traffic hitting the server identified by the index will be sent to the mirror.
+  # mirrors = [["1.2.3.4", 5432, 0], ["1.2.3.4", 5432, 1]]
+
+  # Database name (e.g. "postgres")
+  database = "shard0"
+
+  [pools.sharded_db.shards.1]
+  servers = [["127.0.0.1", 5432, "primary"], ["localhost", 5432, "replica"]]
+  database = "shard1"
+
+  [pools.sharded_db.shards.2]
+  servers = [["127.0.0.1", 5432, "primary" ], ["localhost", 5432, "replica" ]]
+  database = "shard2"
+
+
+  [pools.simple_db]
+  pool_mode = "session"
+  default_role = "primary"
+  query_parser_enabled = true
+  primary_reads_enabled = true
+  sharding_function = "pg_bigint_hash"
+
+  [pools.simple_db.users.0]
+  username = "simple_user"
+  password = "simple_user"
+  pool_size = 5
+  min_pool_size = 3
+  server_lifetime = 60000
+  statement_timeout = 0
+
+  [pools.simple_db.shards.0]
+  servers = [
+      [ "127.0.0.1", 5432, "primary" ],
+      [ "localhost", 5432, "replica" ]
+  ]
+  database = "some_db"
+
+## Containers, which are run before the app containers are started
+##
+extraInitContainers: []
+# - name: init
+#   image: busybox
+#   command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
+
+## Additional volumeMounts to the main container
+##
+extraVolumeMounts: []
+# - name: pgcat-pid
+#   mountPath: "/var/run/pgcat/"
+
+###
+### PgCat Exporter https://postgresml.org/docs/product/pgcat/configuration
+### When enabling, make sure to update podAnnotations: {} accordingly
+pgcatExporter:
+  enabled: true
+  port: 9127
+  image:
+    repository: prometheuscommunity/pgcat-exporter
+    tag: v0.6.0
+    pullPolicy: IfNotPresent
+  log:
+    level: info # or debug, warn, error
+    format: json # or json
+  resources:
+    limits:
+      cpu: 250m
+      memory: 150Mi
+    requests:
+      cpu: 30m
+      memory: 40Mi
+  extraEnv: []
+  # - name: pgcat_USER
+  #   value: bar
+  # - name: pgcat_PWD
+  #   value: bar
+  # - name: pgcat_PORT
+  uncer
+  #   value: bar
+  extraEnvFrom: []
+  # - name: foo
+  #   valueFrom:
+pgcat


### PR DESCRIPTION
# Summary

For us to use pgcat appropriately, it would be good for a helm chart to exist. Given that I do not see any ones out there this is the first implemtantion of a safe deployment of a helm chart for pgcat.

According to the documentation there is a single pgcat.toml that contains the entire configuration needed. This PR will also include an init container that will fetch a secret and populate it in the configmap locally within the container.

# Changes

- feat: initializing pgcat helm chart
